### PR TITLE
Bug: spring security의 cors disable이 적용되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/sequence/proreviewer/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sequence/proreviewer/auth/config/SecurityConfig.java
@@ -1,19 +1,36 @@
 package com.sequence.proreviewer.auth.config;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		return http
-			.cors().disable()
-			.csrf().disable()
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
 			.httpBasic().disable()
-			.build();
+			.csrf().disable()
+			.cors(cors -> corsConfigurationSource());
+
+		return http.build();
+	}
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedHeaders(List.of("*"));
+		configuration.setAllowedOrigins(List.of("*"));
+		configuration.setAllowedMethods(List.of("GET", "POST"));
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 }


### PR DESCRIPTION
## 이슈 번호
- #23 
## 작업 설명
corsConfigurationSource 빈을 추가해 cors disable이 적용되지 않는 버그를 수정했습니다.