### PR TITLE
Feat: github login이 authorization code를 이용해 가능하도록 기능 변경

### DIFF
--- a/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
@@ -4,20 +4,25 @@ import com.google.gson.Gson;
 import com.sequence.proreviewer.auth.application.util.JwtProvider;
 import com.sequence.proreviewer.auth.domain.Auth;
 import com.sequence.proreviewer.auth.domain.Provider;
+import com.sequence.proreviewer.auth.domain.UserInfo;
 import com.sequence.proreviewer.auth.infra.repository.AuthRepository;
 import com.sequence.proreviewer.auth.infra.repository.UserRepository;
+import com.sequence.proreviewer.auth.presentation.dto.request.LoginRequestDto;
 import com.sequence.proreviewer.auth.presentation.dto.response.AuthTokens;
 import com.sequence.proreviewer.user.domain.User;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
@@ -26,11 +31,18 @@ public class AuthService {
 	private final AuthRepository authRepository;
 	private final UserRepository userRepository;
 	private final JwtProvider jwtProvider;
+	private final Environment env;
 
-	public AuthTokens github(String accessToken) {
-		GithubUserInfo userInfo = this.request("https://api.github.com/user", accessToken);
+	public AuthTokens githubLogin(LoginRequestDto dto) {
+		String accessToken = this.getGithubAccessToken(
+			env.getProperty("github.access-token.url"),
+			dto.getCode()
+		);
 
-		Long loginUserId = githubLogin(userInfo);
+		UserInfo userInfo = this.getGithubUserInfo(env.getProperty("github.user-api.url"),
+			accessToken);
+
+		Long loginUserId = login(userInfo);
 		return AuthTokens
 			.builder()
 			.accessToken(jwtProvider.accessToken(String.valueOf(loginUserId)))
@@ -38,7 +50,62 @@ public class AuthService {
 			.build();
 	}
 
-	private Long githubLogin(GithubUserInfo userInfo) {
+	private String getGithubAccessToken(String url, String code) {
+		String clientId = env.getProperty("github.client-id");
+		String clientSecret = env.getProperty("github.client-secret");
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.ACCEPT, "application/json");
+
+		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
+
+		String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
+			.queryParam("client_id", "{clientId}")
+			.queryParam("client_secret", "{clientSecret}")
+			.queryParam("code", "{code}")
+			.encode()
+			.toUriString();
+
+		Map<String, String> params = new HashMap<>();
+		params.put("clientId", clientId);
+		params.put("clientSecret", clientSecret);
+		params.put("code", code);
+
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> res = restTemplate.exchange(
+			urlTemplate,
+			HttpMethod.POST,
+			entity,
+			String.class,
+			params
+		);
+
+		Gson gson = new Gson();
+		System.out.println(gson.fromJson(res.getBody(), HashMap.class));
+		return gson
+			.fromJson(res.getBody(), HashMap.class)
+			.get("access_token")
+			.toString();
+	}
+
+	private UserInfo getGithubUserInfo(String url, String code) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + code);
+		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
+
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> res = restTemplate.exchange(
+			url,
+			HttpMethod.GET,
+			entity,
+			String.class
+		);
+
+		Gson gson = new Gson();
+		return gson.fromJson(res.getBody(), UserInfo.class);
+	}
+
+	private Long login(UserInfo userInfo) {
 		Optional<User> exUser = userRepository.findByEmail(userInfo.getEmail());
 		if (exUser.isEmpty()) {
 			User user = User
@@ -59,31 +126,5 @@ public class AuthService {
 			authRepository.saveAuth(auth);
 		}
 		return exUser.get().getId();
-	}
-
-	private GithubUserInfo request(String uri, String code) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("Authorization", "Bearer " + code);
-
-		HttpEntity<HttpHeaders> request = new HttpEntity<>(headers);
-
-		RestTemplate restTemplate = new RestTemplate();
-		ResponseEntity<String> res = restTemplate.exchange(
-			uri,
-			HttpMethod.GET,
-			request,
-			String.class
-		);
-
-		Gson gson = new Gson();
-		return gson.fromJson(res.getBody(), GithubUserInfo.class);
-	}
-
-	@Getter
-	private class GithubUserInfo {
-
-		private String id;
-		private String name;
-		private String email;
 	}
 }

--- a/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
@@ -1,2 +1,11 @@
-package com.sequence.proreviewer.auth.domain;public class UserInfo {
+package com.sequence.proreviewer.auth.domain;
+
+import lombok.Getter;
+
+@Getter
+public class UserInfo {
+
+	private String id;
+	private String name;
+	private String email;
 }

--- a/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
@@ -1,0 +1,2 @@
+package com.sequence.proreviewer.auth.domain;public class UserInfo {
+}

--- a/src/main/java/com/sequence/proreviewer/auth/presentation/AuthController.java
+++ b/src/main/java/com/sequence/proreviewer/auth/presentation/AuthController.java
@@ -18,7 +18,7 @@ public class AuthController {
 
 	@PostMapping("/login/github")
 	public AuthTokens github(@RequestBody LoginRequestDto dto) {
-		return authService.github(dto.getAccessToken());
+		return authService.githubLogin(dto);
 	}
 
 }

--- a/src/main/java/com/sequence/proreviewer/auth/presentation/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/sequence/proreviewer/auth/presentation/dto/request/LoginRequestDto.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class LoginRequestDto {
 
-	private String accessToken;
+	private String code;
 }


### PR DESCRIPTION
## 이슈 번호
- #22 
## 작업 설명
- UserInfo Class를 domain directory로 옮겼습니다.
- Authorization Code를 사용해 로그인하기 위해 LoginRequestDto의 멤버변수를 변경했습니다.
- Authorization Code를 사용해 로그인하기 위해 Resource Server의 AccessToken을 받아오는 로직을 추가했습니다.
- 추후 google 로그인이 생겼을 때 코드를 리팩터링하기 위해 method의 이름을 변경했습니다.