### PR TITLE
Bug: gradle commons-io 의존성 옵션 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
-    compileOnly 'commons-io:commons-io:2.11.0'
+    implementation 'commons-io:commons-io:2.11.0'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'com.google.code.gson:gson:2.9.1'
 }


### PR DESCRIPTION
## 이슈 번호
- #38 
## 작업 설명
gralde commons-io의 compileOnly를 implementation으로 변경합니다.