### PR TITLE
Refactor: Github, Google 소셜 로그인 기능 리팩터링

### DIFF
--- a/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
@@ -1,8 +1,5 @@
 package com.sequence.proreviewer.auth.application;
 
-import com.google.gson.Gson;
-import com.sequence.proreviewer.auth.application.exception.InvalidAuthorizationCodeException;
-import com.sequence.proreviewer.auth.application.exception.InvalidGithubAccessTokenException;
 import com.sequence.proreviewer.auth.application.util.JwtProvider;
 import com.sequence.proreviewer.auth.domain.Auth;
 import com.sequence.proreviewer.auth.domain.Provider;
@@ -12,20 +9,10 @@ import com.sequence.proreviewer.auth.presentation.dto.request.LoginRequestDto;
 import com.sequence.proreviewer.auth.presentation.dto.response.AuthTokens;
 import com.sequence.proreviewer.user.domain.User;
 import com.sequence.proreviewer.user.domain.repository.UserRepository;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.env.Environment;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Service
 @RequiredArgsConstructor
@@ -34,174 +21,56 @@ public class AuthService {
 	private final AuthRepository authRepository;
 	private final UserRepository userRepository;
 	private final JwtProvider jwtProvider;
-	private final Environment env;
+	private final OAuth2 oAuth2;
 
-	public AuthTokens githubLogin(LoginRequestDto dto) {
-		String accessToken = this.getGithubAccessToken(
-			env.getProperty("github.access-token.url"),
-			dto.getCode()
-		);
+	public AuthTokens login(Provider provider, LoginRequestDto dto) {
+		UserInfo userInfo = oAuth2.getUserInfo(provider, dto.getCode());
 
-		UserInfo userInfo = this.getGithubUserInfo(
-			env.getProperty("github.user-api.url"),
-			accessToken
-		);
+		User user = getUser(userInfo);
+		if (!isAuthExist(userInfo)) {
+			createAuth(user, userInfo, provider);
+		}
 
-		Long loginUserId = login(userInfo);
-		return AuthTokens.builder()
-			.accessToken(jwtProvider.accessToken(String.valueOf(loginUserId)))
-			.refreshToken(UUID.randomUUID().toString())
+		return AuthTokens
+			.builder()
+			.accessToken(createAccessToken(user.getId()))
+			.refreshToken(createRefreshToken())
 			.build();
 	}
 
-	public AuthTokens googleLogin(LoginRequestDto dto) {
-		String accessToken = this.getGoogleAccessToken(
-			env.getProperty("google.access-token.url"),
-			dto.getCode()
-		);
+	private String createAccessToken(Long userId) {
+		return jwtProvider.accessToken(String.valueOf(userId));
+	}
 
-		UserInfo userInfo = this.getGoogleUserInfo(env.getProperty("google.user-api.url"),
-			accessToken);
+	private String createRefreshToken() {
+		return UUID.randomUUID().toString();
+	}
 
-		Long loginUserId = login(userInfo);
-		return AuthTokens.builder()
-			.accessToken(jwtProvider.accessToken(String.valueOf(loginUserId)))
-			.refreshToken(UUID.randomUUID().toString())
+	private void createAuth(User user, UserInfo userInfo, Provider provider) {
+		Auth auth = Auth.builder()
+			.user(user)
+			.providerKey(userInfo.getProviderKey())
+			.provider(provider)
 			.build();
+		authRepository.saveAuth(auth);
 	}
 
-	private String getGoogleAccessToken(String url, String code) {
-		String clientId = env.getProperty("google.client-id");
-		String clientSecret = env.getProperty("google.client-secret");
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set(HttpHeaders.ACCEPT, "application/json");
-		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
-
-		String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
-			.queryParam("client_id", "{clientId}")
-			.queryParam("client_secret", "{clientSecret}")
-			.queryParam("code", "{code}")
-			.queryParam("redirect_uri", "{redirectUri}")
-			.queryParam("grant_type", "{grantType}")
-			.encode()
-			.toUriString();
-
-		Map<String, String> params = new HashMap<>();
-		params.put("clientId", clientId);
-		params.put("clientSecret", clientSecret);
-		params.put("code", code);
-		params.put("grantType", "authorization_code");
-		params.put("redirectUri", env.getProperty("google.redirect-uri"));
-
-		RestTemplate restTemplate = new RestTemplate();
-		ResponseEntity<String> res = restTemplate.exchange(
-			urlTemplate,
-			HttpMethod.POST,
-			entity,
-			String.class,
-			params
-		);
-
-		return new Gson()
-			.fromJson(res.getBody(), HashMap.class)
-			.get("access_token")
-			.toString();
+	private User getUser(UserInfo userInfo) {
+		Optional<User> optionalUser = userRepository.findByEmail(userInfo.getEmail());
+		return optionalUser.orElseGet(() -> createUser(userInfo));
 	}
 
-	private String getGithubAccessToken(String url, String code) {
-		String clientId = env.getProperty("github.client-id");
-		String clientSecret = env.getProperty("github.client-secret");
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set(HttpHeaders.ACCEPT, "application/json");
-		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
-
-		String urlTemplate = UriComponentsBuilder.fromHttpUrl(url)
-			.queryParam("client_id", "{clientId}")
-			.queryParam("client_secret", "{clientSecret}")
-			.queryParam("code", "{code}")
-			.encode()
-			.toUriString();
-
-		Map<String, String> params = new HashMap<>();
-		params.put("clientId", clientId);
-		params.put("clientSecret", clientSecret);
-		params.put("code", code);
-
-		ResponseEntity<String> res = new RestTemplate().exchange(
-			urlTemplate,
-			HttpMethod.POST,
-			entity,
-			String.class,
-			params
-		);
-		HashMap<String, String> resMap = new Gson().fromJson(res.getBody(), HashMap.class);
-
-		String err = resMap.get("error");
-		if (err != null) {
-			throw new InvalidAuthorizationCodeException();
-		}
-
-		return resMap.get("access_token");
+	private User createUser(UserInfo userInfo) {
+		User user = User.builder()
+			.email(userInfo.getEmail())
+			.build();
+		return userRepository.save(user);
 	}
 
-	private UserInfo getGithubUserInfo(String url, String accessToken) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
-
-		ResponseEntity<String> res;
-		try {
-			res = new RestTemplate().exchange(
-				url,
-				HttpMethod.GET,
-				entity,
-				String.class
-			);
-		} catch (RestClientException e) {
-			throw new InvalidGithubAccessTokenException();
-		}
-
-		return new Gson().fromJson(res.getBody(), UserInfo.class);
+	private boolean isAuthExist(UserInfo userInfo) {
+		Optional<Auth> optionalAuth = authRepository.findByProviderKey(userInfo.getId());
+		return optionalAuth.isPresent();
 	}
 
-	private UserInfo getGoogleUserInfo(String url, String accessToken) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
-		HttpEntity<HttpHeaders> entity = new HttpEntity<>(headers);
 
-		ResponseEntity<String> res = new RestTemplate().exchange(
-			url,
-			HttpMethod.GET,
-			entity,
-			String.class
-		);
-
-		return new Gson().fromJson(res.getBody(), UserInfo.class);
-	}
-
-	private Long login(UserInfo userInfo) {
-		Optional<User> exUser = userRepository.findByEmail(userInfo.getEmail());
-		if (exUser.isEmpty()) {
-			User user = User
-				.builder()
-				.email(userInfo.getEmail())
-				.build();
-			exUser = Optional.ofNullable(userRepository.save(user));
-		}
-
-		Optional<Auth> exAuth = this.authRepository.findByProviderKey(userInfo.getId());
-		if (exAuth.isEmpty()) {
-			Auth auth = Auth
-				.builder()
-				.provider(Provider.GITHUB)
-				.providerKey(userInfo.getId())
-				.userId(exUser.get())
-				.build();
-			authRepository.saveAuth(auth);
-		}
-
-		return exUser.get().getId();
-	}
 }

--- a/src/main/java/com/sequence/proreviewer/auth/application/OAuth2.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/OAuth2.java
@@ -1,0 +1,2 @@
+package com.sequence.proreviewer.auth.application;public class OAuth2 {
+}

--- a/src/main/java/com/sequence/proreviewer/auth/application/OAuth2.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/OAuth2.java
@@ -1,2 +1,163 @@
-package com.sequence.proreviewer.auth.application;public class OAuth2 {
+package com.sequence.proreviewer.auth.application;
+
+import com.google.gson.Gson;
+import com.sequence.proreviewer.auth.application.exception.InvalidAccessTokenException;
+import com.sequence.proreviewer.auth.application.exception.InvalidAuthorizationCodeException;
+import com.sequence.proreviewer.auth.domain.Provider;
+import com.sequence.proreviewer.auth.domain.UserInfo;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RequiredArgsConstructor
+@Component
+class OAuth2 {
+
+	private final Environment env;
+	private Provider provider;
+
+	UserInfo getUserInfo(Provider provider, String code) {
+		settingProvider(provider);
+		String accessToken = getAccessToken(code);
+		ResponseEntity<String> response = requestUserInfo(accessToken);
+		return getUserInfoFromResponseBody(response.getBody());
+	}
+
+	private void settingProvider(Provider provider) {
+		this.provider = provider;
+	}
+
+	private String getAccessToken(String code) {
+		ResponseEntity<String> response = requestAccessToken(code);
+		return getAccessTokenFromResponseBody(response.getBody());
+	}
+
+	private ResponseEntity<String> requestAccessToken(String code) {
+		HttpEntity<HttpHeaders> headers = createHttpHeader(
+			HttpHeaders.ACCEPT,
+			"application/json"
+		);
+		String urlTemplate = createRequestAccessTokenUrlTemplate();
+		Map<String, String> params = createRequestAccessTokenRequestParams(code);
+
+		ResponseEntity<String> response;
+		try {
+			response = new RestTemplate().exchange(
+				urlTemplate,
+				HttpMethod.POST,
+				headers,
+				String.class,
+				params
+			);
+		} catch (RestClientException e) {
+			throw new InvalidAuthorizationCodeException();
+		}
+
+		if (provider == Provider.GITHUB
+			&& new Gson().fromJson(response.getBody(), HashMap.class).get("error") != null) {
+			throw new InvalidAuthorizationCodeException();
+		}
+
+		return response;
+	}
+
+	private ResponseEntity<String> requestUserInfo(String accessToken) {
+		String url = getRequestUserInfoUrl();
+		HttpEntity<HttpHeaders> headers = createHttpHeader(
+			HttpHeaders.AUTHORIZATION,
+			"Bearer " + accessToken
+		);
+		try {
+			return new RestTemplate().exchange(
+				url,
+				HttpMethod.GET,
+				headers,
+				String.class
+			);
+		} catch (RestClientException e) {
+			throw new InvalidAccessTokenException();
+		}
+	}
+
+	private String createRequestAccessTokenUrlTemplate() {
+		String requestUrl = getRequestAccessTokenUrl();
+
+		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(requestUrl)
+			.queryParam("client_id", "{clientId}")
+			.queryParam("client_secret", "{clientSecret}")
+			.queryParam("code", "{code}");
+		if (provider == Provider.GOOGLE) {
+			uriComponentsBuilder
+				.queryParam("redirect_uri", "{redirectUri}")
+				.queryParam("grant_type", "{grantType}");
+		}
+		uriComponentsBuilder.encode();
+		return uriComponentsBuilder.toUriString();
+	}
+
+	private Map<String, String> createRequestAccessTokenRequestParams(String code) {
+		Map<String, String> params = new HashMap<>();
+		params.put("clientId", getClientId());
+		params.put("clientSecret", getClientSecret());
+		params.put("code", code);
+		if (provider == Provider.GOOGLE) {
+			params.put("grantType", env.getProperty("google.grant-type"));
+			params.put("redirectUri", env.getProperty("google.redirect-uri"));
+		}
+		return params;
+	}
+
+	private String getAccessTokenFromResponseBody(String responseBody) {
+		return new Gson()
+			.fromJson(responseBody, HashMap.class)
+			.get("access_token")
+			.toString();
+	}
+
+	private UserInfo getUserInfoFromResponseBody(String responseBody) {
+		return new Gson().fromJson(responseBody, UserInfo.class);
+	}
+
+	private HttpEntity<HttpHeaders> createHttpHeader(String name, String value) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(name, value);
+		return new HttpEntity<>(headers);
+	}
+
+	private String getRequestAccessTokenUrl() {
+		if (provider == Provider.GITHUB) {
+			return env.getProperty("github.access-token.url");
+		}
+		return env.getProperty("google.access-token.url");
+	}
+
+	private String getRequestUserInfoUrl() {
+		if (provider == Provider.GITHUB) {
+			return env.getProperty("github.user-api.url");
+		}
+		return env.getProperty("google.user-api.url");
+	}
+
+	private String getClientId() {
+		if (provider == Provider.GITHUB) {
+			return env.getProperty("github.client-id");
+		}
+		return env.getProperty("google.client-id");
+	}
+
+	private String getClientSecret() {
+		if (provider == Provider.GITHUB) {
+			return env.getProperty("github.client-secret");
+		}
+		return env.getProperty("google.client-secret");
+	}
 }

--- a/src/main/java/com/sequence/proreviewer/auth/application/exception/InvalidAccessTokenException.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/exception/InvalidAccessTokenException.java
@@ -3,9 +3,9 @@ package com.sequence.proreviewer.auth.application.exception;
 import com.sequence.proreviewer.common.error.BaseCustomException;
 import com.sequence.proreviewer.common.error.ErrorCode;
 
-public class InvalidGithubAccessTokenException extends BaseCustomException {
+public class InvalidAccessTokenException extends BaseCustomException {
 
-	public InvalidGithubAccessTokenException() {
-		super(ErrorCode.INVALID_GITHUB_ACCESS_TOKEN);
+	public InvalidAccessTokenException() {
+		super(ErrorCode.INVALID_ACCESS_TOKEN);
 	}
 }

--- a/src/main/java/com/sequence/proreviewer/auth/domain/Auth.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/Auth.java
@@ -24,7 +24,7 @@ public class Auth {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
-	private User userId;
+	private User user;
 
 	@NotNull
 	private String providerKey;
@@ -34,8 +34,8 @@ public class Auth {
 	private Provider provider;
 
 	@Builder
-	public Auth(User userId, String providerKey, Provider provider) {
-		this.userId = userId;
+	public Auth(User user, String providerKey, Provider provider) {
+		this.user = user;
 		this.providerKey = providerKey;
 		this.provider = provider;
 	}

--- a/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/UserInfo.java
@@ -8,4 +8,8 @@ public class UserInfo {
 	private String id;
 	private String name;
 	private String email;
+
+	public String getProviderKey() {
+		return this.id;
+	}
 }

--- a/src/main/java/com/sequence/proreviewer/auth/presentation/AuthController.java
+++ b/src/main/java/com/sequence/proreviewer/auth/presentation/AuthController.java
@@ -1,15 +1,14 @@
 package com.sequence.proreviewer.auth.presentation;
 
 import com.sequence.proreviewer.auth.application.AuthService;
+import com.sequence.proreviewer.auth.domain.Provider;
 import com.sequence.proreviewer.auth.presentation.dto.request.LoginRequestDto;
 import com.sequence.proreviewer.auth.presentation.dto.response.AuthTokens;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -19,14 +18,11 @@ public class AuthController {
 
 	private final AuthService authService;
 
-	@PostMapping("/login/google")
-	public AuthTokens google(@RequestBody LoginRequestDto dto) {
-		return authService.googleLogin(dto);
+	@PostMapping("/login/{provider}")
+	public AuthTokens login(@RequestBody LoginRequestDto dto, @PathVariable String provider) {
+		if (Provider.valueOf(provider.toUpperCase()) == Provider.GITHUB) {
+			return authService.login(Provider.GITHUB, dto);
+		}
+		return authService.login(Provider.GOOGLE, dto);
 	}
-
-	@PostMapping("/login/github")
-	public AuthTokens github(@RequestBody LoginRequestDto dto) {
-		return authService.githubLogin(dto);
-	}
-
 }

--- a/src/main/java/com/sequence/proreviewer/common/error/ErrorCode.java
+++ b/src/main/java/com/sequence/proreviewer/common/error/ErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-	INVALID_GITHUB_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "INVALID_GITHUB_ACCESS_TOKEN"),
+	INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED.value(), "INVALID_ACCESS_TOKEN"),
 	INVALID_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED.value(), "INVALID_AUTHORIZATION_CODE"),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "USER_NOT_FOUND");
 

--- a/src/main/java/com/sequence/proreviewer/user/domain/User.java
+++ b/src/main/java/com/sequence/proreviewer/user/domain/User.java
@@ -32,7 +32,7 @@ public class User {
 
 	private String description;
 
-	@OneToMany(mappedBy = "userId", cascade = {CascadeType.REMOVE})
+	@OneToMany(mappedBy = "user", cascade = {CascadeType.REMOVE})
 	private List<Auth> auths;
 
 	@Builder


### PR DESCRIPTION
## 이슈 번호
- #29 
## 작업 설명
- Google, Github 소셜 로그인의 기능을 OAuth2 클래스로 분리했습니다.
- Exception의 이름을 변경했습니다.
- Auth Entitiy의 변수 명을 변경했습니다. ( userId -> user )
- Auth Controller의 소셜 로그인 메소드들을 하나의 메소드로 합쳤습니다.