### PR TITLE
Bug: Gihtub Action으로 Image 빌드 시 JPA의 DB 초기화가 이루어지지 않는 에러 수정 #5

### DIFF
--- a/.github/workflows/push-dev-docker-image.yml
+++ b/.github/workflows/push-dev-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Setup QEMU
-        uses: actions/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2
       -
         name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
## 이슈 번호
- #57 
- #58 
- #59 
- #60 
- #61 
## 작업 설명
#61 의 Setup QEMU step의 actions를 docker로 변경했습니다.