### PR TITLE
Bug: Gihtub Action으로 Image 빌드 시 JPA의 DB 초기화가 이루어지지 않는 에러 수정 #8

### DIFF
--- a/.github/workflows/push-dev-docker-image.yml
+++ b/.github/workflows/push-dev-docker-image.yml
@@ -25,9 +25,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Create secrets.properties
-        run: |
-          printf "${{ secrets.DEV_SECRETS_PROPERTIES }}" >> src/main/resources/secrets.properties
-        shell: bash
+        run: echo "${{ secrets.DEV_SECRETS_PROPERTIES }}" > src/main/resources/secrets.properties
+        uses: actions/upload-artifact@v3
+        with:
+          name: secrets.properties
+          path: src/main/resources/secrets.properties
       -
         name: Build and Push
         uses: docker/build-push-action@v3


### PR DESCRIPTION
## 이슈 번호
- #57 
- #58 
- #59 
- #60 
- #61 
- #62 
- #63
- #64 
## 작업 설명
- Create secrets.properties step에 actions/upload-artifact@v3을 추가했습니다.