### PR TITLE
Bug: Gihtub Action으로 Image 빌드 시 JPA의 DB 초기화가 이루어지지 않는 에러 수정 #9

### DIFF
--- a/.github/workflows/push-dev-docker-image.yml
+++ b/.github/workflows/push-dev-docker-image.yml
@@ -26,6 +26,8 @@ jobs:
       -
         name: Create secrets.properties
         run: echo "${{ secrets.DEV_SECRETS_PROPERTIES }}" > src/main/resources/secrets.properties
+      -
+        name: Cache secrets.properties
         uses: actions/upload-artifact@v3
         with:
           name: secrets.properties


### PR DESCRIPTION
## 이슈 번호
- #57 
- #58 
- #59 
- #60 
- #61 
- #62 
- #63
- #64 
- #65 
## 작업 설명
- Create secrets.properties step에서 Cache secrets.properties step을 분리