### PR TITLE
Bug: Gihtub Action으로 Image 빌드 시 JPA의 DB 초기화가 이루어지지 않는 에러 수정 #10

### DIFF
--- a/.github/workflows/push-dev-docker-image.yml
+++ b/.github/workflows/push-dev-docker-image.yml
@@ -34,8 +34,4 @@ jobs:
           path: src/main/resources/secrets.properties
       -
         name: Build and Push
-        uses: docker/build-push-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/proreviewer-back:dev
+        run: docker buildx build . --push --tag ${{ secrets.DOCKERHUB_USERNAME }}/proreviewer-back:dev

--- a/.github/workflows/push-dev-docker-image.yml
+++ b/.github/workflows/push-dev-docker-image.yml
@@ -27,11 +27,5 @@ jobs:
         name: Create secrets.properties
         run: echo "${{ secrets.DEV_SECRETS_PROPERTIES }}" > src/main/resources/secrets.properties
       -
-        name: Cache secrets.properties
-        uses: actions/upload-artifact@v3
-        with:
-          name: secrets.properties
-          path: src/main/resources/secrets.properties
-      -
         name: Build and Push
         run: docker buildx build . --push --tag ${{ secrets.DOCKERHUB_USERNAME }}/proreviewer-back:dev


### PR DESCRIPTION
## 이슈 번호
- #57 
- #58 
- #59 
- #60 
- #61 
- #62 
- #63
- #64 
- #65 
- #66 
## 작업 설명
- Cache secrets.properties step 삭제
- Build and Push step
  - docker/build-push-action@v3 삭제
  - run: docker buildx build . --push --tag ${{ secrets.DOCKERHUB_USERNAME }}/proreviewer-back:dev 추가