### PR TITLE
Bug: dockerfile build 실패

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.5.1-jdk18-alpine AS builder
+FROM gradle:7.5.1-jdk18 AS builder
 
 WORKDIR /
 


### PR DESCRIPTION
## 이슈 번호
- #78 
## 작업 설명
- `gradle:7.5.1-jdk18-alpine`을 `gradle:7.5.1-jdk18`로 변경했습니다.