### PR TITLE
Refactor: AuthService의 getOAuth2ConcreteClassBean() 메소드가 OCP를 만족하도록 리팩토링

### DIFF
--- a/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
+++ b/src/main/java/com/sequence/proreviewer/auth/application/AuthService.java
@@ -1,7 +1,5 @@
 package com.sequence.proreviewer.auth.application;
 
-import com.sequence.proreviewer.auth.application.oauth2.GithubOAuth2;
-import com.sequence.proreviewer.auth.application.oauth2.GoogleOAuth2;
 import com.sequence.proreviewer.auth.application.oauth2.OAuth2;
 import com.sequence.proreviewer.auth.application.util.JwtProvider;
 import com.sequence.proreviewer.auth.domain.Auth;
@@ -79,9 +77,6 @@ public class AuthService {
     }
 
     private OAuth2 getOAuth2ConcreteClassBean(Provider provider) {
-        if (provider == Provider.GITHUB) {
-            return context.getBean(GithubOAuth2.class);
-        }
-        return context.getBean(GoogleOAuth2.class);
+        return context.getBean(provider.getOAuth2ConcreteClass());
     }
 }

--- a/src/main/java/com/sequence/proreviewer/auth/domain/Provider.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/Provider.java
@@ -1,6 +1,16 @@
 package com.sequence.proreviewer.auth.domain;
 
+import com.sequence.proreviewer.auth.application.oauth2.GithubOAuth2;
+import com.sequence.proreviewer.auth.application.oauth2.GoogleOAuth2;
+import com.sequence.proreviewer.auth.application.oauth2.OAuth2;
+
 public enum Provider {
-    GOOGLE,
-    GITHUB
+    GOOGLE(GoogleOAuth2.class),
+    GITHUB(GithubOAuth2.class);
+
+    private final Class<? extends OAuth2> oAuth2ConcreteClass;
+
+    Provider(Class<? extends OAuth2> oAuth2ConcreteClass) {
+        this.oAuth2ConcreteClass = oAuth2ConcreteClass;
+    }
 }

--- a/src/main/java/com/sequence/proreviewer/auth/domain/Provider.java
+++ b/src/main/java/com/sequence/proreviewer/auth/domain/Provider.java
@@ -3,7 +3,9 @@ package com.sequence.proreviewer.auth.domain;
 import com.sequence.proreviewer.auth.application.oauth2.GithubOAuth2;
 import com.sequence.proreviewer.auth.application.oauth2.GoogleOAuth2;
 import com.sequence.proreviewer.auth.application.oauth2.OAuth2;
+import lombok.Getter;
 
+@Getter
 public enum Provider {
     GOOGLE(GoogleOAuth2.class),
     GITHUB(GithubOAuth2.class);


### PR DESCRIPTION
## 이슈 번호
- #84 
## 작업 설명
- Provider에 oAuth2ConcreteClass 상수값을 추가했습니다.
- Provider에 lombok의 @Getter를 추가했습니다.
- AuthService의 getOAuth2ConcreteClassBean() 메소드가 Provider의 getOAuth2ConcreteClass() 메소드를 사용하여 OCP를 만족하도록 했습니다.